### PR TITLE
change: set `alwaysShowIcons` default value to true

### DIFF
--- a/Editor/SavedSettings.cs
+++ b/Editor/SavedSettings.cs
@@ -455,7 +455,7 @@ namespace DreadScripts.HierarchyPlus
 			showTransformIcon = new SavedBool(false),
 			showNonBehaviourIcons = new SavedBool(true),
 			linkCursorOnHover = new SavedBool(false),
-			alwaysShowIcons = new SavedBool(false),
+			alwaysShowIcons = new SavedBool(true),
 			iconBackgroundColorEnabled = new SavedBool(true),
 			iconBackgroundOverlapOnly = new SavedBool(true),
 			labelsEnabled = new SavedBool(true),


### PR DESCRIPTION
The original default setting often cause users to miss components when the gameobject's name is very long.